### PR TITLE
create variable for #checkboxLabel display attribute

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -161,7 +161,7 @@ Custom property | Description | Default
       /* label */
       #checkboxLabel {
         position: relative;
-        display: inline-block;
+        display: var(--paper-checkbox-label-display, inline-block);
         vertical-align: middle;
         padding-left: 8px;
         white-space: normal;


### PR DESCRIPTION
This allows us to get rid of the invisible 8px padding when trying to create a column of centered checkboxes.
